### PR TITLE
Refactor security analysis to avoid duplicate resource reporting

### DIFF
--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -23,4 +23,15 @@ type Metadata struct {
 	Labels            map[string]string `json:"labels,omitempty"`
 	Annotations       map[string]string `json:"annotations,omitempty"`
 	CreationTimestamp string            `json:"creationTimestamp,omitempty"`
+	OwnerReferences   []OwnerReference  `json:"ownerReferences,omitempty"`
+}
+
+// OwnerReference contains the information to identify an owner object
+type OwnerReference struct {
+	APIVersion         string `json:"apiVersion,omitempty"`
+	Kind               string `json:"kind,omitempty"`
+	Name               string `json:"name,omitempty"`
+	UID                string `json:"uid,omitempty"`
+	Controller         bool   `json:"controller,omitempty"`
+	BlockOwnerDeletion bool   `json:"blockOwnerDeletion,omitempty"`
 }


### PR DESCRIPTION
- Add OwnerReference to Metadata struct to track pod owners
- Modify security analysis functions to prioritize higher-level controllers
- Avoid showing duplicate resources by using parent resources (DeploymentSet, DaemonSet)
- Keep important control-plane pods in host namespace results
- Implement proper deduplication with resource hierarchy prioritization

🤖 Generated with [Claude Code](https://claude.ai/code)